### PR TITLE
Fix dependency version - web3

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "snarkjs": "0.1.9",
     "stealth_eth": "git+https://github.com/eddieoz/stealth_eth.git",
     "truffle": "5.0.1",
-    "web3": "1.0.0-beta.37"
+    "web3": "1.2.1"
   },
   "devDependencies": {
     "cryptiles": ">=4.1.2",


### PR DESCRIPTION
When I tried to install the dependencies, nodejs indicated many vulnerabilities from the package Web3. The package.json indicates the version 1.0.0-beta, however, the latest release of this library is the version 1.2.1 which contains several stability improvements, including atualization of dependencies that were vulnerable, and it is still compatible with node 8.